### PR TITLE
<code> and <file> blocks inline highlighting

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,9 @@ To disable it use ":unlet". Example:
   :unlet dokuwiki_comment
 
 If you want to enable the code blocks highlighting for some languages,
-assign any value to the 'dokuwiki_code_highlighting' variable. Example:
-  :let dokuwiki_code_highlighting=1
+assign their names to the 'dokuwiki_code_language' variable (assuming
+that there are corresponding syntax files in your Vim installation).
+Example:
+  :let dokuwiki_code_languages="bash,c,make,lisp"
 To disable code block highlighting use ":unlet". Example:
-  :unlet dokuwiki_code_highlighting
+  :unlet dokuwiki_code_languages

--- a/README
+++ b/README
@@ -9,3 +9,9 @@ any value to the 'dokuwiki_comment' variable. Example:
   :let dokuwiki_comment=1
 To disable it use ":unlet". Example:
   :unlet dokuwiki_comment
+
+If you want to enable the code blocks highlighting for some languages,
+assign any value to the 'dokuwiki_code_highlighting' variable. Example:
+  :let dokuwiki_code_highlighting=1
+To disable code block highlighting use ":unlet". Example:
+  :unlet dokuwiki_code_highlighting

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -113,6 +113,7 @@ if exists("dokuwiki_code_languages")
     endif
     exe 'syntax include @inc' . mylang . " ". mylangfile
     exe 'syntax region ' . mylang . 'Code matchgroup=Comment start="<code\s\+'. mylang . '\(\s\+[^>]\+\)\?>" end="</code>" contains=@inc' . mylang
+    exe 'syntax region ' . mylang . 'File matchgroup=Comment start="<file\s\+'. mylang . '\(\s\+[^>]\+\)\?>" end="</file>" contains=@inc' . mylang
   endfor
 endif
 

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -98,17 +98,19 @@ syn region dokuwikiCodeLang start="\s\+\zs" end=">"me=e-1 contained contains=dok
 syn region dokuwikiCodeFileName start="\zs\s\+" end=">"me=e-1 contained contains=@NoSpell
 
 "Special highlighting for language Code Blocks
-for mylang in ["bash", "lisp", "make", "c"]
-  let b:current_syntax = ''
-  unlet b:current_syntax
-  if mylang == "bash"
-    let mylangfile = "syntax/sh.vim"
-  else
-    let mylangfile = "syntax/" . mylang . ".vim"
-  endif
-  exe 'syntax include @inc' . mylang . " ". mylangfile
-  exe 'syntax region ' . mylang . 'Code matchgroup=Comment start="<code\s\+'. mylang . '\(\s\+[^>]\+\)\?>" end="</code>" contains=@inc' . mylang
-endfor
+if exists("dokuwiki_code_highlighting")
+  for mylang in ["bash", "lisp", "make", "c"]
+    let b:current_syntax = ''
+    unlet b:current_syntax
+    if mylang == "bash"
+      let mylangfile = "syntax/sh.vim"
+    else
+      let mylangfile = "syntax/" . mylang . ".vim"
+    endif
+    exe 'syntax include @inc' . mylang . " ". mylangfile
+    exe 'syntax region ' . mylang . 'Code matchgroup=Comment start="<code\s\+'. mylang . '\(\s\+[^>]\+\)\?>" end="</code>" contains=@inc' . mylang
+  endfor
+endif
 
 " Lists
 syn match dokuwikiList "^\(  \|\t\)\s*[*-]" contains=@dokuwikiTextItems

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -98,10 +98,15 @@ syn region dokuwikiCodeLang start="\s\+\zs" end=">"me=e-1 contained contains=dok
 syn region dokuwikiCodeFileName start="\zs\s\+" end=">"me=e-1 contained contains=@NoSpell
 
 "Special highlighting for language Code Blocks
-for mylang in ["sh", "lisp", "make", "c"]
+for mylang in ["bash", "lisp", "make", "c"]
   let b:current_syntax = ''
   unlet b:current_syntax
-  exe 'syntax include @inc' . mylang . " syntax/" . mylang . ".vim"
+  if mylang == "bash"
+    let mylangfile = "syntax/sh.vim"
+  else
+    let mylangfile = "syntax/" . mylang . ".vim"
+  endif
+  exe 'syntax include @inc' . mylang . " ". mylangfile
   exe 'syntax region ' . mylang . 'Code matchgroup=Comment start="<code\s\+'. mylang . '\(\s\+[^>]\+\)\?>" end="</code>" contains=@inc' . mylang
 endfor
 

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -102,7 +102,7 @@ for mylang in ["sh", "lisp", "make", "c"]
   let b:current_syntax = ''
   unlet b:current_syntax
   exe 'syntax include @inc' . mylang . " syntax/" . mylang . ".vim"
-  exe 'syntax region dokuwiki' . mylang . ' start="<code ' . mylang . '"' . ' end="</code>" contains=@inc' . mylang
+  exe 'syntax region ' . mylang . 'Code matchgroup=Comment start="<code\s\+'. mylang . '\(\s\+[^>]\+\)\?>" end="</code>" contains=@inc' . mylang
 endfor
 
 " Lists

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -97,6 +97,14 @@ syn region dokuwikiFileBlockContent start=">"ms=e+1 end="</file>"me=s-1 containe
 syn region dokuwikiCodeLang start="\s\+\zs" end=">"me=e-1 contained contains=dokuwikiCodeFileName,@NoSpell
 syn region dokuwikiCodeFileName start="\zs\s\+" end=">"me=e-1 contained contains=@NoSpell
 
+"Special highlighting for language Code Blocks
+for mylang in ["sh", "lisp", "make", "c"]
+  let b:current_syntax = ''
+  unlet b:current_syntax
+  exe 'syntax include @inc' . mylang . " syntax/" . mylang . ".vim"
+  exe 'syntax region dokuwiki' . mylang . ' start="<code ' . mylang . '"' . ' end="</code>" contains=@inc' . mylang
+endfor
+
 " Lists
 syn match dokuwikiList "^\(  \|\t\)\s*[*-]" contains=@dokuwikiTextItems
 

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -98,8 +98,12 @@ syn region dokuwikiCodeLang start="\s\+\zs" end=">"me=e-1 contained contains=dok
 syn region dokuwikiCodeFileName start="\zs\s\+" end=">"me=e-1 contained contains=@NoSpell
 
 "Special highlighting for language Code Blocks
-if exists("dokuwiki_code_highlighting")
-  for mylang in ["bash", "lisp", "make", "c"]
+if exists("dokuwiki_code_languages")
+  let languages = split (dokuwiki_code_languages, "[ ,]")
+  for mylang in languages
+    if mylang == ''
+      continue
+    endif
     let b:current_syntax = ''
     unlet b:current_syntax
     if mylang == "bash"


### PR DESCRIPTION
Hello, Florian
I've added support for \<code\> and \<file\> blocks inline highlighting.
Details are described in README. Please look at this.

Regards,
  Vladimir