### PR TITLE
add syntax highlighting and header-based folding, etc

### DIFF
--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -48,14 +48,15 @@ syn match dokuwikiHeading4 /^\s*=\{3}[^=]\+.*[^=]\+=\{3}\s*$/
 syn match dokuwikiHeading5 /^\s*=\{2}[^=]\+.*[^=]\+=\{2}\s*$/
 
 " Highlight
-syn region dokuwikiBold start="\*\*" end="\*\*" contains=ALLBUT,dokuwikiBold,@dokuwikiNoneTextItem extend
-syn region dokuwikiItalic start="\/\/" end="\/\/" contains=ALLBUT,dokuwikiItalic,@dokuwikiNoneTextItem extend
-syn region dokuwikiUnderlined start="__" end="__" contains=ALLBUT,dokuwikiUnderlined,@dokuwikiNoneTextItem extend
-syn region dokuwikiMonospaced start="''" end="''" contains=ALLBUT,dokuwikiMonospaced,@dokuwikiNoneTextItem extend
+" A matchgroup is necessary to make concealends work.
+syn region dokuwikiBold matchgroup=FoldColumn start="\*\*" end="\*\*" contains=ALLBUT,dokuwikiBold,@dokuwikiNoneTextItem extend concealends
+syn region dokuwikiItalic matchgroup=FoldColumn start="\/\/" end="\/\/" contains=ALLBUT,dokuwikiItalic,@dokuwikiNoneTextItem extend concealends
+syn region dokuwikiUnderlined matchgroup=FoldColumn start="__" end="__" contains=ALLBUT,dokuwikiUnderlined,@dokuwikiNoneTextItem extend concealends
+syn region dokuwikiMonospaced matchgroup=FoldColumn start="''" end="''" contains=ALLBUT,dokuwikiMonospaced,@dokuwikiNoneTextItem extend concealends
 
-syn region dokuwikiStrikethrough start="<del>" end="</del>" contains=ALLBUT,@dokuwikiNoneTextItem,dokuwikiStrikethrough extend
-syn region dokuwikiSubscript start="<sub>" end="</sub>" contains=ALLBUT,@dokuwikiNoneTextItem,dokuwikiStrikethrough extend
-syn region dokuwikiSuperscript start="<sup>" end="</sup>" contains=ALLBUT,@dokuwikiNoneTextItem,dokuwikiStrikethrough extend
+syn region dokuwikiStrikethrough matchgroup=FoldColumn start="<del>" end="</del>" contains=ALLBUT,@dokuwikiNoneTextItem,dokuwikiStrikethrough extend concealends
+syn region dokuwikiSubscript matchgroup=FoldColumn start="<sub>" end="</sub>" contains=ALLBUT,@dokuwikiNoneTextItem,dokuwikiSubscript extend concealends
+syn region dokuwikiSuperscript matchgroup=FoldColumn start="<sup>" end="</sup>" contains=ALLBUT,@dokuwikiNoneTextItem,dokuwikiSuperscript extend concealends
 
 " Smileys: http://github.com/splitbrain/dokuwiki/blob/master/conf/smileys.conf
 syn match dokuwikiSmiley "\(8-)\|8-O\|8-o\|:-(\|:-)\|=)\|:-\/\|:-\\\)" contains=@NoSpell

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -23,6 +23,8 @@ if !exists('main_syntax')
 endif
 
 "Settings
+" Use syntax-based folding
+setlocal foldmethod=syntax
 " Set shift width for indent
 setlocal shiftwidth=2
 " Set the tab key size to two spaces
@@ -54,11 +56,11 @@ syn region dokuwikiNowiki start=+%%+ end=+%%+
 syn region dokuwikiNowiki start=+<nowiki>+ end=+</nowiki>+
 
 " Heading
-syn match dokuwikiHeading1 /^\s*=\{6}[^=]\+.*[^=]\+=\{6}\s*$/
-syn match dokuwikiHeading2 /^\s*=\{5}[^=]\+.*[^=]\+=\{5}\s*$/
-syn match dokuwikiHeading3 /^\s*=\{4}[^=]\+.*[^=]\+=\{4}\s*$/
-syn match dokuwikiHeading4 /^\s*=\{3}[^=]\+.*[^=]\+=\{3}\s*$/
-syn match dokuwikiHeading5 /^\s*=\{2}[^=]\+.*[^=]\+=\{2}\s*$/
+syn region dokuwikiHeading1 matchgroup=dokuwikiHeading1mg start="^=\{6}\s.\+\s=\{6}$" end="^\ze\(=\{6,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3,dokuwikiHeading2
+syn region dokuwikiHeading2 matchgroup=dokuwikiHeading2mg start="^=\{5}\s.\+\s=\{5}$" end="^\ze\(=\{5,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3
+syn region dokuwikiHeading3 matchgroup=dokuwikiHeading3mg start="^=\{4}\s.\+\s=\{4}$" end="^\ze\(=\{4,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4
+syn region dokuwikiHeading4 matchgroup=dokuwikiHeading4mg start="^=\{3}\s.\+\s=\{3}$" end="^\ze\(=\{3,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5
+syn region dokuwikiHeading5 matchgroup=dokuwikiHeading5mg start="^=\{2}\s.\+\s=\{2}$" end="^\ze\(=\{2,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList
 
 " Highlight
 " A matchgroup is necessary to make concealends work.
@@ -103,6 +105,7 @@ syn cluster dokuwikiTextItems contains=dokuwikiBold,dokuwikiItalic,dokuwikiUnder
 syn cluster dokuwikiTextItems add=dokuwikiSubscript,dokuwikiSuperscript,dokuwikiSmiley,dokuwikiEntities
 syn cluster dokuwikiTextItems add=dokuwikiExternalLink,dokuwikiInternalLink,dokuwikiMediaLink
 syn cluster dokuwikiTextItems add=dokuwikiFootnotes,dokuwikiLinebreak,dokuwikiNowiki,dokuwikiCodeBlock
+syn cluster dokuwikiBlockItems add=@dokuwikiTextItems,dokuwikiCodeBlockPlain,dokuwikiHorizontalLine,dokuwikiQuotes,dokuwikiTable,dokuwikiEmbedded,dokuwikiControlMacros
 syn cluster dokuwikiNoneTextItem contains=ALLBUT,@dokuwikiTextItems
 
 " Links: http://github.com/splitbrain/dokuwiki/blob/master/conf/scheme.conf
@@ -137,7 +140,6 @@ if main_syntax ==# 'dokuwiki'
   endfor
   unlet! s:type
 endif
-
 
 " Lists
 syn match dokuwikiList "^\(  \|\t\)\s*[*-]" contains=@dokuwikiTextItems
@@ -174,15 +176,15 @@ hi link dokuwikiLinebreak Keyword
 
 hi link dokuwikiNowiki Exception
 
-hi link dokuwikiHeading1 Title
-hi link dokuwikiHeading2 Title
-hi link dokuwikiHeading3 Title
-hi link dokuwikiHeading4 Title
-hi link dokuwikiHeading5 Title
+hi def dokuwikiHeading1mg term=bold cterm=bold ctermfg=2 gui=bold guifg=#ff00ff
+hi def dokuwikiHeading2mg term=bold cterm=bold ctermfg=5 gui=bold guifg=#cc33ff
+hi def dokuwikiHeading3mg term=bold cterm=bold ctermfg=4 gui=bold guifg=#9966ff
+hi def dokuwikiHeading4mg term=bold cterm=bold ctermfg=1 gui=bold guifg=#6699ff
+hi def dokuwikiHeading5mg term=bold cterm=bold ctermfg=6 gui=bold guifg=#33ccff
 
 hi def dokuwikiBold term=bold cterm=bold gui=bold
 hi def dokuwikiItalic term=italic cterm=italic gui=italic
-hi link dokuwikiUnderlined Underlined
+hi def dokuwikiUnderlined term=underline cterm=underline gui=underline
 hi link dokuwikiMonospaced Type
 hi link dokuwikiStrikethrough DiffDelete
 hi link dokuwikiSubscript Special

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -225,3 +225,7 @@ hi link dokuwikiHorizontalLine NonText
 
 "set name
 let b:current_syntax = "dokuwiki"
+if main_syntax ==# 'dokuwiki'
+  unlet main_syntax
+endif
+

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -29,6 +29,8 @@ setlocal shiftwidth=2
 setlocal softtabstop=2
 " Let tab keys always be expanded to spaces
 setlocal expandtab
+" Show conceal text when editing a line
+setlocal concealcursor=nc
 
 """ Patterns
 " Keywords
@@ -61,9 +63,26 @@ syn match dokuwikiSmiley "\(:-\\\|:-?\|:-D\|:-P\|:-o\|:-O\|:-x\)" contains=@NoSp
 syn match dokuwikiSmiley "\(:-X\|:-|\|;-)\|m(\|\^_\^\|:?:\|:!:\)\|LOL\|FIXME\|DELETEME" contains=@NoSpell
 
 " Entities: http://github.com/splitbrain/dokuwiki/blob/master/conf/entities.conf
-syn match dokuwikiEntities "\(<->\|->\|<-\|<=>\|640x480\)" contains=@NoSpell
-syn match dokuwikiEntities "\(=>\|<=[^>]\|>>\|<<\|---\|--\)" contains=@NoSpell
-syn match dokuwikiEntities "\((c)\|(tm)\|(r)\|\.\.\.\)" contains=@NoSpell
+set conceallevel=2
+syn match dokuwikiEntities "<->" conceal cchar=↔
+syn match dokuwikiEntities "->" conceal cchar=→
+syn match dokuwikiEntities "<-\ze\([^>]\|$\)" conceal cchar=←
+syn match dokuwikiEntities "<=>" conceal cchar=⇔
+syn match dokuwikiEntities "=>" conceal cchar=⇒
+syn match dokuwikiEntities "<=\ze\([^>]\|$\)" conceal cchar=⇐
+
+syn match dokuwikiEntities "\( \|^\|\d\)\zsx\ze\d" conceal cchar=×
+syn match dokuwikiEntities "\C\d\zsx\ze\($\|\s\|[0-9A-Z]\)" conceal cchar=×
+
+syn match dokuwikiEntities "<<" conceal cchar=«
+syn match dokuwikiEntities ">>" conceal cchar=»
+syn match dokuwikiEntities "--\ze\([^-]\|$\)" conceal cchar=–
+syn match dokuwikiEntities "---\ze\([^-]\|$\)" conceal cchar=—
+syn match dokuwikiEntities "(c)" conceal cchar=©
+syn match dokuwikiEntities "(tm)" conceal cchar=™
+syn match dokuwikiEntities "(r)" conceal cchar=®
+syn match dokuwikiEntities "\.\.\." conceal cchar=…
+
 
 "Cluster most common items
 syn cluster dokuwikiTextItems contains=dokuwikiBold,dokuwikiItalic,dokuwikiUnderlined,dokuwikiMonospaced,dokuwikiStrikethrough

--- a/test/test_syntax.txt
+++ b/test/test_syntax.txt
@@ -181,20 +181,26 @@ Plain code block:
 
 Using %%<code> ... </code>%%:
 <code>
-<code> block here
+<code> block here </file>
 </code>
 
-Using %%<file> ... </file>%%: <file> <file> block here </file>
+Using %%<file> ... </file>%%: <file> <file> block here </code> </file>
 
 Syntax highlighting:
-<file java  filename.jar>
-/**
- * Example of java code syntax highlighting
- */
-class HelloWorldApp {
-    //TBD
-}
-</file>
+<code java> <code> <file> /*comment*/ class Foo {
+	// static variables
+	</file>
+	public int c=5,String s="fred"; }
+</code>
+<code unknownLang> <code> block here </file> </code>
+
+<code java foo.java> <code> <file> /*comment*/ class Foo {
+	// static variables
+	</file>
+	public int c=5,String s="fred"; }
+</code>
+<code unknownLang fileName> <code> block here </file> </code>
+
 
 ====== Quotes ======
 I think we should do it

--- a/test/test_syntax.txt
+++ b/test/test_syntax.txt
@@ -67,7 +67,7 @@ or '-' is not required, so these lists are valid, too:
   * :-| (icon_neutral.gif)
   * ;-) (icon_wink.gif)
   * m( (facepalm.gif)
-  *  ^_^ (icon_fun.gif)
+  * ^_^ (icon_fun.gif)
   * :?: (icon_question.gif)
   * :!: (icon_exclaim.gif)
   * LOL (icon_lol.gif)


### PR DESCRIPTION
I've been using this syntax file regularly for over a year now and this is my accumulated improvements.

Changes:
1. Imported fenced code blocks from the markdown syntax file. When enabled, applies the correct syntax highlighting for the code.
2. Header based folding. I like folds. Using heading levels seemed like the obvious way to do it.
3. Used "conceal" to replace entities with the unicode character that dokuwiki will use. Also hide the markup for basic formatting. You don't need it when you have highlighting.