### PR TITLE
Header syntax: spaces optional

### DIFF
--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -84,11 +84,11 @@ syn region dokuwikiNowiki start=+%%+ end=+%%+
 syn region dokuwikiNowiki start=+<nowiki>+ end=+</nowiki>+
 
 " Heading: ==== title ====
-syn region dokuwikiHeading1 matchgroup=dokuwikiHeading1mg start="^=\{6}\s.\+\s=\{6}$" end="^\ze\(=\{6,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3,dokuwikiHeading2
-syn region dokuwikiHeading2 matchgroup=dokuwikiHeading2mg start="^=\{5}\s.\+\s=\{5}$" end="^\ze\(=\{5,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3
-syn region dokuwikiHeading3 matchgroup=dokuwikiHeading3mg start="^=\{4}\s.\+\s=\{4}$" end="^\ze\(=\{4,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4
-syn region dokuwikiHeading4 matchgroup=dokuwikiHeading4mg start="^=\{3}\s.\+\s=\{3}$" end="^\ze\(=\{3,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5
-syn region dokuwikiHeading5 matchgroup=dokuwikiHeading5mg start="^=\{2}\s.\+\s=\{2}$" end="^\ze\(=\{2,6}\)\s.*\s\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList
+syn region dokuwikiHeading1 matchgroup=dokuwikiHeading1mg start="^=\{6}.\+=\{6}$" end="^\ze\(=\{6,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3,dokuwikiHeading2
+syn region dokuwikiHeading2 matchgroup=dokuwikiHeading2mg start="^=\{5}.\+=\{5}$" end="^\ze\(=\{5,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3
+syn region dokuwikiHeading3 matchgroup=dokuwikiHeading3mg start="^=\{4}.\+=\{4}$" end="^\ze\(=\{4,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4
+syn region dokuwikiHeading4 matchgroup=dokuwikiHeading4mg start="^=\{3}.\+=\{3}$" end="^\ze\(=\{3,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5
+syn region dokuwikiHeading5 matchgroup=dokuwikiHeading5mg start="^=\{2}.\+=\{2}$" end="^\ze\(=\{2,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList
 
 " Basic Formatting: **bold**, //italic//, __underline__, ''monospace'', etc
 " A matchgroup is necessary to make concealends work with regions.


### PR DESCRIPTION
Although headers clearly look better with spaces separating the `=` and heading text, their use is not mandatory. Fix the regex for this.

Credits to @IgnoredAmbience, somehow I couldn't create a PR directly from his fork.