### PR TITLE
ftdetect *.txt interferes with default filetype detection

### DIFF
--- a/ftdetect/dokuwiki.vim
+++ b/ftdetect/dokuwiki.vim
@@ -1,4 +1,3 @@
 autocmd BufRead,BufNewFile *.dokuwiki  set filetype=dokuwiki
 autocmd BufRead,BufNewFile *.dwiki     set filetype=dokuwiki
 autocmd BufRead,BufNewFile *.dw        set filetype=dokuwiki
-autocmd BufRead,BufNewFile *.txt       set filetype=dokuwiki


### PR DESCRIPTION
I noticed that the most recent commit added filetype detection. Thanks for adding that!

However, I have encountered a minor issue recently while contributing to a C++ project that appears to be an unintended side-effect. The following [line in `ftdetect/dokuwiki.vim:4`](https://github.com/nblock/vim-dokuwiki/blob/fe799dbd5c535dae627db46dd67c3f44f7d7e4a2/ftdetect/dokuwiki.vim#L4) is interfering with other ftdetect configs (in my case, CMake):

```vim
autocmd BufRead,BufNewFile *.txt       set filetype=dokuwiki
```

Vim's built-in detection assigns `filetype=cmake` for `CMakeLists.txt`, but this is overridden by the line above.

Anyone who would like for all `*.txt` files to be treated as `dokuwiki` can add the above line to their `.vimrc`/`init.vim` or a custom `ftdetect/dokuwiki.vim` script within their own runtime directory.