### PR TITLE
Surround maps. Nested folds. Snippets.

### DIFF
--- a/ftdetect/dokuwiki.vim
+++ b/ftdetect/dokuwiki.vim
@@ -1,3 +1,20 @@
 autocmd BufRead,BufNewFile *.dokuwiki  set filetype=dokuwiki
 autocmd BufRead,BufNewFile *.dwiki     set filetype=dokuwiki
 autocmd BufRead,BufNewFile *.dw        set filetype=dokuwiki
+
+" Surround plugin's mappings.
+" Select in Visual, press S and b to make bold text.
+" Now supported: bold, italic, underlined, monospace, link, headers.
+" See:
+" https://github.com/tpope/vim-surround
+" :h surround-customizing 
+autocmd FileType dokuwiki let b:surround_{char2nr('b')} = "** \r **"
+autocmd FileType dokuwiki let b:surround_{char2nr('i')} = "// \r //"
+autocmd FileType dokuwiki let b:surround_{char2nr('u')} = "__ \r __"
+autocmd FileType dokuwiki let b:surround_{char2nr('m')} = "'' \r ''"
+autocmd FileType dokuwiki let b:surround_{char2nr('l')} = "[[|\r]]"
+autocmd FileType dokuwiki let b:surround_{char2nr('1')} = "====== \r ======"
+autocmd FileType dokuwiki let b:surround_{char2nr('2')} = "===== \r ====="
+autocmd FileType dokuwiki let b:surround_{char2nr('3')} = "==== \r ===="
+autocmd FileType dokuwiki let b:surround_{char2nr('4')} = "=== \r ==="
+autocmd FileType dokuwiki let b:surround_{char2nr('5')} = "== \r =="

--- a/snippets/dokuwiki.snippets
+++ b/snippets/dokuwiki.snippets
@@ -1,0 +1,191 @@
+# Long form (for smart completters like YCM)
+snippet header1
+	====== ${0} ======
+
+snippet header2
+	===== ${0} =====
+
+snippet header3
+	==== ${0} ====
+
+snippet header4
+	=== ${0} ===
+
+snippet header5
+	== ${0} ==
+
+snippet bold
+	** ${0} **
+snippet italic
+	// ${0} //
+snippet underlined
+	__ ${0} __
+snippet monospaced
+	'' ${0} ''
+snippet subscript
+	<sub> ${0} </sub>
+snippet superscript
+	<sup> ${0} </sup>
+snippet deleted
+	<del> ${0} </del>
+snippet link
+	[[${0:text}|${1:link}]]
+snippet list
+	  * ${0}
+
+snippet list_ordered
+	  - ${0}
+
+snippet table
+	^ Heading 1      ^ Heading 2       ^ Heading 3          ^
+	| Row 1 Col 1    | Row 1 Col 2     | Row 1 Col 3        |
+	| Row 2 Col 1    | some colspan (note the double pipe) ||
+	| Row 3 Col 1    | Row 3 Col 2     | Row 3 Col 3        |
+
+snippet code
+	<code>
+		${0}
+	</code>
+
+# Short forms (for fast type)
+snippet h1
+	====== ${0} ======
+
+snippet h2
+	===== ${0} =====
+
+snippet h3
+	==== ${0} ====
+
+snippet h4
+	=== ${0} ===
+
+snippet h5
+	== ${0} ==
+
+snippet b
+	** ${0} **
+snippet i
+	// ${0} //
+snippet u
+	__ ${0} __
+snippet m
+	'' ${0} ''
+snippet sub
+	<sub> ${0} </sub>
+snippet sup
+	<sup> ${0} </sup>
+snippet del
+	<del> ${0} </del>
+snippet ln
+	[[${0:text}|${1:link}]]
+snippet li
+	  * ${0}
+
+snippet lo
+	  - ${0}
+
+snippet tab
+	^ Heading 1      ^ Heading 2       ^ Heading 3          ^
+	| Row 1 Col 1    | Row 1 Col 2     | Row 1 Col 3        |
+	| Row 2 Col 1    | some colspan (note the double pipe) ||
+	| Row 3 Col 1    | Row 3 Col 2     | Row 3 Col 3        |
+
+snippet c
+	<code>
+		${0}
+	</code>
+
+# Long form russian
+snippet заголовок1
+	====== ${0} ======
+
+snippet заголовок2
+	===== ${0} =====
+
+snippet заголовок3
+	==== ${0} ====
+
+snippet заголовок4
+	=== ${0} ===
+
+snippet заголовок5
+	== ${0} ==
+
+snippet жирный
+	** ${0} **
+snippet курсив
+	// ${0} //
+snippet подчеркнутый
+	__ ${0} __
+snippet моношрифт
+	'' ${0} ''
+snippet снизу
+	<sub> ${0} </sub>
+snippet сверху
+	<sup> ${0} </sup>
+snippet удаленный
+	<del> ${0} </del>
+snippet ссылка
+	[[${0:text}|${1:link}]]
+snippet список
+	  * ${0}
+
+snippet список_упорядоченный
+	  - ${0}
+
+snippet таблица
+	^ Heading 1      ^ Heading 2       ^ Heading 3          ^
+	| Row 1 Col 1    | Row 1 Col 2     | Row 1 Col 3        |
+	| Row 2 Col 1    | some colspan (note the double pipe) ||
+	| Row 3 Col 1    | Row 3 Col 2     | Row 3 Col 3        |
+
+snippet код
+	<code>
+		${0}
+	</code>
+
+# Short forms (for fast type)
+snippet з1
+	====== ${0} ======
+
+snippet з2
+	===== ${0} =====
+
+snippet з3
+	==== ${0} ====
+
+snippet з4
+	=== ${0} ===
+
+snippet з5
+	== ${0} ==
+
+snippet ж
+	** ${0} **
+snippet к
+	// ${0} //
+snippet п
+	__ ${0} __
+snippet м
+	'' ${0} ''
+snippet низ
+	<sub> ${0} </sub>
+snippet верх
+	<sup> ${0} </sup>
+snippet уд
+	<del> ${0} </del>
+snippet сс
+	[[${0:text}|${1:link}]]
+snippet сп
+	  * ${0}
+
+snippet спу
+	  - ${0}
+
+snippet табл
+	^ Heading 1      ^ Heading 2       ^ Heading 3          ^
+	| Row 1 Col 1    | Row 1 Col 2     | Row 1 Col 3        |
+	| Row 2 Col 1    | some colspan (note the double pipe) ||
+	| Row 3 Col 1    | Row 3 Col 2     | Row 3 Col 3        |
+

--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -84,11 +84,11 @@ syn region dokuwikiNowiki start=+%%+ end=+%%+
 syn region dokuwikiNowiki start=+<nowiki>+ end=+</nowiki>+
 
 " Heading: ==== title ====
-syn region dokuwikiHeading1 matchgroup=dokuwikiHeading1mg start="^=\{6}.\+=\{6}$" end="^\ze\(=\{6,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3,dokuwikiHeading2
-syn region dokuwikiHeading2 matchgroup=dokuwikiHeading2mg start="^=\{5}.\+=\{5}$" end="^\ze\(=\{5,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3
-syn region dokuwikiHeading3 matchgroup=dokuwikiHeading3mg start="^=\{4}.\+=\{4}$" end="^\ze\(=\{4,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4
-syn region dokuwikiHeading4 matchgroup=dokuwikiHeading4mg start="^=\{3}.\+=\{3}$" end="^\ze\(=\{3,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5
-syn region dokuwikiHeading5 matchgroup=dokuwikiHeading5mg start="^=\{2}.\+=\{2}$" end="^\ze\(=\{2,6}\).*\1$" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList
+syn region dokuwikiHeading1 matchgroup=dokuwikiHeading1mg start="^=\{6}[^=]\+=\{6}$" end=".*\ze\(^=\{6}[^=]\+=\{6}$\)" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3,dokuwikiHeading2
+syn region dokuwikiHeading2 matchgroup=dokuwikiHeading2mg start="^=\{5}[^=]\+=\{5}$" end=".*\ze\(^=\{5,6}[^=]\+=\{5,6}$\)" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4,dokuwikiHeading3
+syn region dokuwikiHeading3 matchgroup=dokuwikiHeading3mg start="^=\{4}[^=]\+=\{4}$" end=".*\ze\(^=\{4,6}[^=]\+=\{4,6}$\)" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5,dokuwikiHeading4
+syn region dokuwikiHeading4 matchgroup=dokuwikiHeading4mg start="^=\{3}[^=]\+=\{3}$" end=".*\ze\(^=\{3,6}[^=]\+=\{3,6}$\)" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList,dokuwikiHeading5
+syn region dokuwikiHeading5 matchgroup=dokuwikiHeading5mg start="^=\{2}[^=]\+=\{2}$" end=".*\ze\(^=\{2,6}[^=]\+=\{2,6}$\)" fold contains=@Spell,@dokuwikiBlockItems,dokuwikiList
 
 " Basic Formatting: **bold**, //italic//, __underline__, ''monospace'', etc
 " A matchgroup is necessary to make concealends work with regions.


### PR DESCRIPTION
Added mappings for Tim Pope's surround plugin.
See ftdetect/dokuwiki.vim.

Changed patterns for headers, now foldings are nested.
See syntax/dokuwiki.vim.

Added snippets for SnipMate/UltiSnips on english and russian.
See snippets/dokuwiki.vim.