### PR TITLE
Define a separate dokuwikiTodo for FIXME and DELETEME

### DIFF
--- a/syntax/dokuwiki.vim
+++ b/syntax/dokuwiki.vim
@@ -105,7 +105,8 @@ syn region dokuwikiSuperscript matchgroup=FoldColumn start="<sup>" end="</sup>" 
 " Smileys: http://github.com/splitbrain/dokuwiki/blob/master/conf/smileys.conf
 syn match dokuwikiSmiley "\(8-)\|8-O\|8-o\|:-(\|:-)\|=)\|:-\/\|:-\\\)" contains=@NoSpell
 syn match dokuwikiSmiley "\(:-\\\|:-?\|:-D\|:-P\|:-o\|:-O\|:-x\)" contains=@NoSpell
-syn match dokuwikiSmiley "\(:-X\|:-|\|;-)\|m(\|\^_\^\|:?:\|:!:\)\|LOL\|FIXME\|DELETEME" contains=@NoSpell
+syn match dokuwikiSmiley "\(:-X\|:-|\|;-)\|m(\|\^_\^\|:?:\|:!:\)\|LOL" contains=@NoSpell
+syn keyword dokuwikiTodo FIXME DELETEME
 
 " Entities: http://github.com/splitbrain/dokuwiki/blob/master/conf/entities.conf
 syn match dokuwikiEntities "<->" conceal cchar=↔
@@ -195,7 +196,7 @@ syn match dokuwikiHorizontalLine "^\s\?----\+\s*$"
 """ Clusters {{{
 " @dokuwikiTextItems are those that work well in-line
 syn cluster dokuwikiTextItems contains=dokuwikiBold,dokuwikiItalic,dokuwikiUnderlined,dokuwikiMonospaced,dokuwikiStrikethrough
-syn cluster dokuwikiTextItems add=dokuwikiSubscript,dokuwikiSuperscript,dokuwikiSmiley,dokuwikiEntities
+syn cluster dokuwikiTextItems add=dokuwikiSubscript,dokuwikiSuperscript,dokuwikiSmiley,dokuwikiTodo,dokuwikiEntities
 syn cluster dokuwikiTextItems add=dokuwikiExternalLink,dokuwikiInternalLink,dokuwikiMediaLink
 syn cluster dokuwikiTextItems add=dokuwikiFootnotes,dokuwikiLinebreak,dokuwikiNowiki,dokuwikiCodeBlock
 
@@ -234,6 +235,7 @@ hi link dokuwikiMediaCaption Label
 hi link dokuwikiMediaLink Include
 
 hi link dokuwikiSmiley Todo
+hi link dokuwikiTodo Todo
 hi link dokuwikiEntities Keyword
 
 hi link dokuwikiList Identifier


### PR DESCRIPTION
These have been lumped together with the smileys, but serve different purposes: The latter convey emotions, but the former alert maintainers to problems (and as such, users may want to emphasize those, e.g. with boldface and a glaring yellow background).
As `FIXME` and `DELETEME` are just alphabetic characters, `:syn keyword` is used (this wouldn't be possible for the smileys) - this also prevents inadvertent matching inside other text (PREFIXMEDIATION).
Keep the default linking to the `Todo` group for smileys to maintain backwards compatibility - users have to customize if they want to distinguish both.